### PR TITLE
Ensure callback is invoked when there are no migration to run.

### DIFF
--- a/lib/models/migration.js
+++ b/lib/models/migration.js
@@ -146,6 +146,7 @@ module.exports = function(Migration, options) {
         migrationCallStack[migrationCallIndex]();
       } else {
         delete Migration.app.migrating;
+        cb();
         Migration.emit('complete');
         Migration.log.info('No new migrations to run.');
       }

--- a/test/test.js
+++ b/test/test.js
@@ -101,6 +101,21 @@ describe('loopback db migrate', function() {
     });
 
     describe('up', function() {
+      it('should callback when there a no migrations to run', function(done) {
+        var self = this;
+        var previousDir = app.models.Migration.migrationsDir;
+        app.models.Migration.migrationsDir = path.join(previousDir, '..', '..');
+        app.models.Migration.migrate()
+          .then(function() {
+            self.expectNoUp();
+            self.expectNoDown();
+            done();
+          })
+          .catch(done)
+          .finally(function () {
+            app.models.Migration.migrationsDir = previousDir;
+          });
+      });
       it('should run all migration scripts', function(done) {
         var self = this;
         app.models.Migration.migrate()


### PR DESCRIPTION
When there are no migration to be run, either because they've all been run or because there aren't any, the callback of migrate isn't invoked. 

This patch makes sure the invocation terminates.
